### PR TITLE
Fix compatibility with Symfony 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
         # Test against LTS versions
         - php: 7.0
           env: SYMFONY_VERSION=2.8.*
+        - php: 7.1
+          env: SYMFONY_VERSION=3.4.* DEPENDENCIES=dev
     allow_failures:
         - php: hhvm
         - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "1.4.x-dev"
         }
     }
 }

--- a/src/Command/CompareCommand.php
+++ b/src/Command/CompareCommand.php
@@ -2,7 +2,8 @@
 
 namespace Incenteev\TranslationCheckerBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Incenteev\TranslationCheckerBundle\Translator\ExposingTranslator;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -10,8 +11,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Translation\Catalogue\TargetOperation;
 use Symfony\Component\Translation\MessageCatalogue;
 
-class CompareCommand extends ContainerAwareCommand
+class CompareCommand extends Command
 {
+    private $exposingTranslator;
+
+    public function __construct(ExposingTranslator $exposingTranslator)
+    {
+        parent::__construct();
+
+        $this->exposingTranslator = $exposingTranslator;
+    }
+
     protected function configure()
     {
         $this->setName('incenteev:translation:compare')
@@ -40,10 +50,8 @@ EOF
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $loader = $this->getContainer()->get('incenteev_translation_checker.exposing_translator');
-
-        $sourceCatalogue = $loader->getCatalogue($input->getArgument('source'));
-        $comparedCatalogue = $loader->getCatalogue($input->getArgument('locale'));
+        $sourceCatalogue = $this->exposingTranslator->getCatalogue($input->getArgument('source'));
+        $comparedCatalogue = $this->exposingTranslator->getCatalogue($input->getArgument('locale'));
 
         // Change the locale of the catalogue as DiffOperation requires operating on a single locale
         $catalogue = new MessageCatalogue($sourceCatalogue->getLocale(), $comparedCatalogue->all());

--- a/src/Command/FindMissingCommand.php
+++ b/src/Command/FindMissingCommand.php
@@ -2,15 +2,27 @@
 
 namespace Incenteev\TranslationCheckerBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Incenteev\TranslationCheckerBundle\Translator\ExposingTranslator;
+use Incenteev\TranslationCheckerBundle\Translator\Extractor\ExtractorInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Translation\Catalogue\TargetOperation;
 use Symfony\Component\Translation\MessageCatalogue;
 
-class FindMissingCommand extends ContainerAwareCommand
+class FindMissingCommand extends Command
 {
+    private $exposingTranslator;
+    private $extractor;
+
+    public function __construct(ExposingTranslator $exposingTranslator, ExtractorInterface $extractor)
+    {
+        parent::__construct();
+        $this->exposingTranslator = $exposingTranslator;
+        $this->extractor = $extractor;
+    }
+
     protected function configure()
     {
         $this->setName('incenteev:translation:find-missing')
@@ -31,11 +43,9 @@ HELP
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $extractedCatalogue = new MessageCatalogue($input->getArgument('locale'));
-        $extractor = $this->getContainer()->get('incenteev_translation_checker.extractor');
-        $extractor->extract($extractedCatalogue);
+        $this->extractor->extract($extractedCatalogue);
 
-        $loader = $this->getContainer()->get('incenteev_translation_checker.exposing_translator');
-        $loadedCatalogue = $loader->getCatalogue($input->getArgument('locale'));
+        $loadedCatalogue = $this->exposingTranslator->getCatalogue($input->getArgument('locale'));
 
         $operation = new TargetOperation($loadedCatalogue, $extractedCatalogue);
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -28,5 +28,16 @@
             <argument type="collection" />
             <argument />
         </service>
+
+        <service id="incenteev_translation_checker.command.compare" class="Incenteev\TranslationCheckerBundle\Command\CompareCommand">
+            <tag name="console.command" alias="incenteev:translation:compare" />
+            <argument type="service" id="incenteev_translation_checker.exposing_translator" />
+        </service>
+
+        <service id="incenteev_translation_checker.command.find_missing" class="Incenteev\TranslationCheckerBundle\Command\FindMissingCommand">
+            <tag name="console.command" alias="incenteev:translation:find-missing" />
+            <argument type="service" id="incenteev_translation_checker.exposing_translator" />
+            <argument type="service" id="incenteev_translation_checker.extractor" />
+        </service>
     </services>
 </container>

--- a/tests/Command/CompareCommandTest.php
+++ b/tests/Command/CompareCommandTest.php
@@ -17,14 +17,10 @@ class CompareCommandTest extends TestCase
     {
         $loader = $this->prophesize('Incenteev\TranslationCheckerBundle\Translator\ExposingTranslator');
 
-        $container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container->get('incenteev_translation_checker.exposing_translator')->willReturn($loader);
-
         $loader->getCatalogue($sourceLocale)->willReturn(new MessageCatalogue($sourceLocale, $sourceMessages));
         $loader->getCatalogue($comparedLocale)->willReturn(new MessageCatalogue($comparedLocale, $comparedMessages));
 
-        $command = new CompareCommand();
-        $command->setContainer($container->reveal());
+        $command = new CompareCommand($loader->reveal());
 
         $tester = new CommandTester($command);
         $exitCode = $tester->execute($input, array('decorated' => false, 'verbosity' => $verbosity));

--- a/tests/Command/FindMissingCommandTest.php
+++ b/tests/Command/FindMissingCommandTest.php
@@ -19,10 +19,6 @@ class FindMissingCommandTest extends TestCase
         $loader = $this->prophesize('Incenteev\TranslationCheckerBundle\Translator\ExposingTranslator');
         $extractor = $this->prophesize('Incenteev\TranslationCheckerBundle\Translator\Extractor\ExtractorInterface');
 
-        $container = $this->prophesize('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container->get('incenteev_translation_checker.exposing_translator')->willReturn($loader);
-        $container->get('incenteev_translation_checker.extractor')->willReturn($extractor);
-
         $loader->getCatalogue($locale)->willReturn(new MessageCatalogue($locale, $sourceMessages));
 
         $extractor->extract(Argument::type('Symfony\Component\Translation\MessageCatalogue'))->will(function ($args) use ($extractedMessages) {
@@ -32,8 +28,7 @@ class FindMissingCommandTest extends TestCase
             $catalogue->addCatalogue(new MessageCatalogue($catalogue->getLocale(), $extractedMessages));
         });
 
-        $command = new FindMissingCommand();
-        $command->setContainer($container->reveal());
+        $command = new FindMissingCommand($loader->reveal(), $extractor->reveal());
 
         $tester = new CommandTester($command);
         $exitCode = $tester->execute(array('locale' => $locale), array('decorated' => false, 'verbosity' => $verbosity));


### PR DESCRIPTION
Commands are now registered as services as auto-discovery of commands is deprecated.