### PR TITLE
Remove CI on HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,12 @@ matrix:
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable' SYMFONY_DEPRECATIONS_HELPER=weak
         - php: 7.1
           env: DEPENDENCIES=dev SYMFONY_DEPRECATIONS_HELPER=weak
-        - php: hhvm
-          dist: trusty
         - php: 5.3
           dist: precise
         # Test against LTS versions
         - php: 7.0
           env: SYMFONY_VERSION=2.8.*
     allow_failures:
-        - php: hhvm
         - php: nightly
 
 sudo: false


### PR DESCRIPTION
HHVM [announced](http://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html) that they will stop working on PHP compatibility for HHVM and Symfony dropped support for HHVM. So there is no point keeping it on CI.