### PR TITLE
Add a whitelist feature for the locale comparison

### DIFF
--- a/tests/fixtures/invalid_whitelist.yml
+++ b/tests/fixtures/invalid_whitelist.yml
@@ -1,0 +1,1 @@
+invalid

--- a/tests/fixtures/whitelist.yml
+++ b/tests/fixtures/whitelist.yml
@@ -1,0 +1,3 @@
+incenteev_tests:
+    - this key can go missing
+    - this.one.also


### PR DESCRIPTION
This is useful in case some third-party packages have missing messages in some of their locales, and the project does not care about these keys (because the corresponding feature is not used for instance).