### PR TITLE
Fix the reporting of deprecations in the testsuite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,4 +13,7 @@
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/src/Translator/ExposingTranslator.php
+++ b/src/Translator/ExposingTranslator.php
@@ -3,13 +3,15 @@
 namespace Incenteev\TranslationCheckerBundle\Translator;
 
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
+use Symfony\Component\Translation\MessageCatalogueInterface;
 
 /**
  * Class extending the translator to expose the catalogue loading.
+ * @internal
  */
 class ExposingTranslator extends Translator
 {
-    public function getCatalogue($locale = null)
+    public function getCatalogue($locale = null): MessageCatalogueInterface
     {
         if (null === $locale) {
             $locale = $this->getLocale();

--- a/tests/FixtureApp/TestKernel.php
+++ b/tests/FixtureApp/TestKernel.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class TestKernel extends Kernel
 {
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return array(
             new FrameworkBundle(),
@@ -18,7 +18,7 @@ class TestKernel extends Kernel
         );
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(function (ContainerBuilder $container) {
             $container->loadFromExtension('framework', array(
@@ -30,7 +30,7 @@ class TestKernel extends Kernel
         });
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         // Fake implementation so that the old root_dir/Resources/translations and the new project_dir/translations both
         // map to the same folder in our fixture app to avoid getting a deprecation warning when running tests with 4.2+
@@ -38,12 +38,12 @@ class TestKernel extends Kernel
         return __DIR__.'/Resources';
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return sys_get_temp_dir().'/incenteev_translation_checker';
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return $this->getCacheDir();
     }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -39,7 +39,7 @@ class FunctionalTest extends KernelTestCase
         $this->assertSame($expectedExitCode, $application->run($input, $output));
     }
 
-    public static function provideComparisonCases()
+    public static function provideComparisonCases(): iterable
     {
         return array(
             array('fr', true),
@@ -47,7 +47,7 @@ class FunctionalTest extends KernelTestCase
         );
     }
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         return 'Incenteev\TranslationCheckerBundle\Tests\FixtureApp\TestKernel';
     }


### PR DESCRIPTION
The test listener needs to be registered in the config when the `simple-phpunit` script is not used.