### PR TITLE
Add the testing keyword for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "incenteev/translation-checker-bundle",
     "type": "symfony-bundle",
     "description": "CLI tools to check translations in a Symfony project",
-    "keywords": ["translation check", "translation"],
+    "keywords": ["translation check", "translation", "testing"],
     "homepage": "https://github.com/Incenteev/translation-checker-bundle",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This makes composer suggest adding this package as a dev requirement, which is the expected usage of the bundle.